### PR TITLE
Clean up service account keys when deleting chatbot

### DIFF
--- a/src/services/reusableFirebaseProjectService.ts
+++ b/src/services/reusableFirebaseProjectService.ts
@@ -29,6 +29,7 @@ export class ReusableFirebaseProjectService {
         oauthClients: false,
         webApps: false,
         identityPlatform: false,
+        serviceAccountKeys: false,
       };
 
       // 1. Clean up OAuth clients (fixes accumulation issue)
@@ -97,6 +98,22 @@ export class ReusableFirebaseProjectService {
         }
       } catch (error) {
         console.error('❌ Identity Platform cleanup failed:', error);
+      }
+
+      // 7. Clean up service account keys
+      try {
+        const projectId = process.env.REUSABLE_FIREBASE_PROJECT_ID;
+        if (projectId) {
+          const auth = new google.auth.GoogleAuth({
+            scopes: ['https://www.googleapis.com/auth/cloud-platform']
+          });
+          const authClient = await auth.getClient();
+          await this.cleanupServiceAccountKeys(projectId, authClient);
+          cleanupResults.serviceAccountKeys = true;
+          console.log('✅ Service account keys cleanup completed');
+        }
+      } catch (error) {
+        console.error('❌ Service account keys cleanup failed:', error);
       }
       
       const successCount = Object.values(cleanupResults).filter(Boolean).length;


### PR DESCRIPTION
## Summary
- delete old service account keys when cleaning up a reusable Firebase project
- add `serviceAccountKeys` result indicator for cleanup

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_684b34cf28488323af962a7a2724038b