### PR TITLE
Fix TypeScript error in chatbot status check

### DIFF
--- a/src/app/dashboard/chatbots/[id]/page.tsx
+++ b/src/app/dashboard/chatbots/[id]/page.tsx
@@ -555,7 +555,7 @@ export default function ChatbotDetailPage() {
                       </CardHeader>
                       <CardContent>
                         <div className="flex items-center">
-                          <span className={`h-3 w-3 rounded-full ${chatbot.status === 'deployed' ? 'bg-green-500' : 'bg-yellow-500'} mr-2`}></span>
+                          <span className={`h-3 w-3 rounded-full ${chatbot.deployment?.status === 'deployed' ? 'bg-green-500' : 'bg-yellow-500'} mr-2`}></span>
                           <div className="text-sm font-medium">{chatbot.status || 'Draft'}</div>
                         </div>
                       </CardContent>


### PR DESCRIPTION
Fixes #14

Fixed TypeScript compilation error that was causing Vercel builds to fail.

**Root cause**: The code was comparing `chatbot.status === 'deployed'` but the `status` field only accepts `'draft' | 'preview' | 'active' | 'paused' | 'archived'`.

**Solution**: Changed to `chatbot.deployment?.status === 'deployed'` which correctly checks the deployment status field.

Generated with [Claude Code](https://claude.ai/code)