### PR TITLE
Fix Safari-specific OAuth redirect timing issues

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -38,6 +38,11 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
+      // Set a flag for Safari OAuth handling
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem('oauth_redirect_pending', 'true');
+      }
+      
       await signInWithGoogle();
       // Don't manually redirect here - let AuthContext handle it
       // This prevents race conditions with ProtectedRoute
@@ -46,7 +51,13 @@ export default function LoginPage() {
       if (error.message === 'REDIRECT_INITIATED') {
         // For Safari, the redirect has been initiated, so we don't set an error
         // The page will navigate away, so we don't need to set loading to false
+        // Keep the sessionStorage flag for ProtectedRoute detection
         return;
+      }
+      
+      // Clear the flag if there was an error
+      if (typeof window !== 'undefined') {
+        sessionStorage.removeItem('oauth_redirect_pending');
       }
       
       setError(error.message || 'Failed to sign in with Google');


### PR DESCRIPTION
Fixes #16

Addresses the persistent Safari login redirect issue by implementing Safari-specific timing adjustments and better OAuth flow detection.

## Changes:
- Enhanced AuthContext with Safari-specific delayed redirects (1-1.5s)
- Added sessionStorage flag for OAuth redirect state tracking
- Extended ProtectedRoute timeout for Safari from 2s to 4s
- Improved OAuth callback detection with sessionStorage indicator
- Added proper cleanup of OAuth flags on success/error

## Technical Details:
- Safari's security model requires longer processing time for OAuth redirects
- Uses sessionStorage to track OAuth state across navigation
- Implements graduated timeouts: Safari=4s, others=2s in ProtectedRoute
- AuthContext delays Safari redirects by 1s to avoid race conditions

Generated with [Claude Code](https://claude.ai/code)