### PR TITLE
Fix YouTube OAuth redirect_uri_mismatch error

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ DATABASE_URL=your-database-url
 NEXT_PUBLIC_APP_URL=http://localhost:3000
 NEXT_PUBLIC_API_BASE_URL=http://localhost:3000/api
 
+# YouTube OAuth Configuration
+# Get these from Google Cloud Console > APIs & Services > Credentials
+YOUTUBE_CLIENT_ID=your-youtube-client-id.apps.googleusercontent.com
+YOUTUBE_CLIENT_SECRET=your-youtube-client-secret
+# Important: In Google OAuth client, add these redirect URIs:
+# - http://localhost:3000/api/youtube/callback (for development)
+# - https://your-production-domain.com/api/youtube/callback (for production)
+
 # REUSABLE FIREBASE PROJECT CONFIGURATION (for development)
 # Set to 'true' to reuse a pre-created Firebase project instead of creating new ones
 USE_REUSABLE_FIREBASE_PROJECT=false

--- a/YOUTUBE_OAUTH_SETUP.md
+++ b/YOUTUBE_OAUTH_SETUP.md
@@ -1,0 +1,81 @@
+# YouTube OAuth Setup Guide
+
+This guide will help you fix the `redirect_uri_mismatch` error when connecting to YouTube.
+
+## The Problem
+
+The error `Error 400: redirect_uri_mismatch` occurs when the redirect URI in your OAuth request doesn't match what's configured in your Google OAuth client.
+
+## Solution Steps
+
+### 1. Set Up Environment Variables
+
+Add these required environment variables to your `.env.local` file (copy from `.env.example`):
+
+```bash
+# YouTube OAuth Configuration
+YOUTUBE_CLIENT_ID=your-actual-client-id.apps.googleusercontent.com
+YOUTUBE_CLIENT_SECRET=your-actual-client-secret
+NEXT_PUBLIC_APP_URL=https://your-production-domain.com
+```
+
+### 2. Configure Google OAuth Client
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Select your project (or create one)
+3. Navigate to **APIs & Services** > **Credentials**
+4. Find your OAuth 2.0 Client ID or create a new one
+5. Click **Edit** on your OAuth client
+6. In **Authorized redirect URIs**, add:
+   - `http://localhost:3000/api/youtube/callback` (for development)
+   - `https://your-actual-domain.com/api/youtube/callback` (for production)
+
+### 3. Enable Required APIs
+
+Make sure these APIs are enabled in Google Cloud Console:
+1. **YouTube Data API v3**
+2. **Google+ API** (legacy, but still required for OAuth)
+
+### 4. Check Your Domain
+
+The `NEXT_PUBLIC_APP_URL` environment variable must match exactly with:
+- The domain where your app is deployed
+- The redirect URI configured in Google OAuth client
+
+## Common Issues
+
+### Domain Mismatch
+- ❌ `NEXT_PUBLIC_APP_URL=http://localhost:3000` but production is `https://chatfactory.ai`
+- ✅ `NEXT_PUBLIC_APP_URL=https://chatfactory.ai` for production
+
+### Missing Environment Variables
+- ❌ `YOUTUBE_CLIENT_ID` not set
+- ✅ All YouTube OAuth variables properly configured
+
+### Incorrect Redirect URI
+- ❌ Redirect URI: `https://example.com/callback` 
+- ✅ Redirect URI: `https://example.com/api/youtube/callback`
+
+## Testing
+
+After configuration:
+1. Restart your development server
+2. Try connecting to YouTube again
+3. Check browser network tab for the actual redirect URI being used
+4. Verify it matches what's configured in Google OAuth client
+
+## Production Deployment
+
+For Vercel/production deployment:
+1. Set environment variables in your hosting platform
+2. Update `NEXT_PUBLIC_APP_URL` to your production domain
+3. Add production redirect URI to Google OAuth client
+4. Redeploy your application
+
+## Contact
+
+If you continue to have issues, check:
+- Environment variables are properly set
+- Google OAuth client configuration
+- API quotas and limits
+- Browser console for additional error details

--- a/src/components/youtube/YouTubeApiKeysForm.tsx
+++ b/src/components/youtube/YouTubeApiKeysForm.tsx
@@ -125,6 +125,13 @@ export default function YouTubeApiKeysForm({
               {typeof window !== 'undefined' ? window.location.origin : 'your-domain.com'}/api/youtube/callback
             </code> to authorized redirect URIs</li>
           </ol>
+          
+          <Alert className="mt-3">
+            <Info className="h-4 w-4" />
+            <AlertDescription>
+              <strong>Troubleshooting redirect_uri_mismatch:</strong> This error occurs when the redirect URI above doesn't exactly match what's configured in your Google OAuth client. Make sure to add both development (localhost) and production URLs to your authorized redirect URIs.
+            </AlertDescription>
+          </Alert>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4">


### PR DESCRIPTION
Fix YouTube OAuth redirect_uri_mismatch error

- Add missing YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET to .env.example
- Create comprehensive YOUTUBE_OAUTH_SETUP.md guide
- Add troubleshooting alert to YouTubeApiKeysForm component
- Document required redirect URIs for both development and production

Fixes #26

Generated with [Claude Code](https://claude.ai/code)