### PR TITLE
feat: implement conditional WizeChat logo navigation

### DIFF
--- a/src/components/shared/Header.tsx
+++ b/src/components/shared/Header.tsx
@@ -49,10 +49,10 @@ export default function Header({
           <div className="flex justify-between h-16 items-center">
             {/* Left section with logo */}
             <div className="flex items-center">
-              <div className="flex items-center space-x-3">
+              <Link href={user ? "/dashboard" : "/"} className="flex items-center space-x-3">
                 <img src="/logo.svg" alt="WizeChat" className="h-10 w-10" />
                 <div className="font-bold text-xl text-gradient">WizeChat</div>
-              </div>
+              </Link>
               
               {/* Free plan badge - hidden on mobile, shown on tablet+ */}
               {userProfile?.subscription.plan === 'free' && (
@@ -284,7 +284,7 @@ export default function Header({
   return (
     <header className={`${isDark ? 'fixed w-full top-0 z-10 bg-gray-900/80 backdrop-blur-sm' : 'bg-card border-b border-border'} py-4 ${className}`}>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-between items-center">
-        <Link href="/" className="flex items-center space-x-3">
+        <Link href={user ? "/dashboard" : "/"} className="flex items-center space-x-3">
           <img src="/logo.svg" alt="WizeChat" className="h-10 w-10" />
           <div className={`font-bold text-xl ${isDark ? 'text-white' : 'text-foreground'}`}>WizeChat</div>
         </Link>

--- a/src/components/shared/MarketingHeader.tsx
+++ b/src/components/shared/MarketingHeader.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Home, Menu, X } from "lucide-react";
 import { useState } from "react";
 import { ThemeToggle } from "@/components/ui/theme-toggle";
+import { useAuth } from "@/contexts/AuthContext";
 
 interface MarketingHeaderProps {
   showHomeButton?: boolean;
@@ -20,6 +21,7 @@ export default function MarketingHeader({
   className = ""
 }: MarketingHeaderProps) {
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const { user } = useAuth();
   
   return (
     <header className={`bg-background/80 backdrop-blur-sm border-b border-border/20 shadow-sm sticky top-0 z-50 ${className}`}>
@@ -27,7 +29,7 @@ export default function MarketingHeader({
         <div className="flex justify-between h-16 items-center">
           {/* Logo section - responsive */}
           <div className="flex items-center">
-            <Link href="/" className="flex items-center space-x-3">
+            <Link href={user ? "/dashboard" : "/"} className="flex items-center space-x-3">
               <img src="/logo.svg" alt="WizeChat" className="h-10 w-10" />
               {/* Hide text on mobile, show on desktop */}
               <div className="font-bold text-xl text-gradient hidden sm:block">WizeChat</div>


### PR DESCRIPTION
This PR implements conditional navigation for the WizeChat logo/icon based on user authentication state.

## Changes
- Logo now navigates to /dashboard when user is logged in
- Logo navigates to / (landing page) when user is not logged in
- Applied to both Header.tsx and MarketingHeader.tsx components
- Uses useAuth hook to check authentication state

Fixes #28

🤖 Generated with [Claude Code](https://claude.ai/code)